### PR TITLE
Add GitHub Pages for detailed coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,6 +73,14 @@ jobs:
           name: coverage-report
           path: coverage/
 
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./coverage/test
+          destination_dir: coverage
+
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ZSpec
 
 [![CI](https://github.com/apotema/zspec/actions/workflows/ci.yml/badge.svg)](https://github.com/apotema/zspec/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/apotema/7c6cd8ebc93fc49290cc036271dca4cc/raw/coverage.json)](https://github.com/apotema/zspec/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/apotema/7c6cd8ebc93fc49290cc036271dca4cc/raw/coverage.json)](https://apotema.github.io/zspec/coverage/)
 
 RSpec-like testing framework for Zig.
 


### PR DESCRIPTION
## Summary

Deploy the kcov HTML coverage report to GitHub Pages so developers can see exactly which lines are covered/uncovered.

## Changes

- Add `peaceiris/actions-gh-pages` step to deploy coverage HTML report
- Coverage badge now links to the detailed report at https://apotema.github.io/zspec/coverage/
- Report updates automatically on each push to main

## What You'll See

The kcov report shows:
- File-by-file coverage breakdown
- Line-by-line highlighting (green = covered, red = uncovered)
- Function coverage statistics
- Overall project coverage summary

## Setup Required

After merging, enable GitHub Pages in repo settings:
1. Go to Settings → Pages
2. Set Source to "Deploy from a branch"
3. Select `gh-pages` branch, `/ (root)` folder

Closes #10