### PR TITLE
fix: Handle nested struct coercion in Factory.defineFrom()

### DIFF
--- a/src/factory.zig
+++ b/src/factory.zig
@@ -316,6 +316,12 @@ fn FactoryImpl(comptime T: type, comptime defaults: anytype, comptime depth: usi
                 }
             }
 
+            // Handle anonymous struct to named struct coercion
+            // e.g., .build(.{ .tint = .{ .r = 255, ... } }) -> Color{ .r = 255, ... }
+            if (@typeInfo(FieldType) == .@"struct" and @typeInfo(OverrideType) == .@"struct") {
+                return buildTypedPayload(FieldType, override_value);
+            }
+
             // Coerce compatible types
             return @as(FieldType, override_value);
         }
@@ -501,6 +507,12 @@ fn TraitFactoryImpl(comptime T: type, comptime base_defaults: anytype, comptime 
                     ptr.* = buildNestedStruct(ChildType, override_value);
                     return ptr;
                 }
+            }
+
+            // Handle anonymous struct to named struct coercion
+            // e.g., .build(.{ .tint = .{ .r = 255, ... } }) -> Color{ .r = 255, ... }
+            if (@typeInfo(FieldType) == .@"struct" and @typeInfo(OverrideType) == .@"struct") {
+                return buildTypedPayload(FieldType, override_value);
             }
 
             // Coerce compatible types

--- a/tests/factory_zon_test.zig
+++ b/tests/factory_zon_test.zig
@@ -243,4 +243,32 @@ pub const DEFINE_FROM_NESTED_STRUCT = struct {
         try expect.equal(sprite.tint.g, 0);
         try expect.equal(sprite.tint.b, 0);
     }
+
+    test "callsite override with anonymous nested struct" {
+        // Override using anonymous struct syntax at build() callsite
+        const sprite = SpriteVisualFactory.build(.{
+            .tint = .{ .r = 0, .g = 255, .b = 0, .a = 128 },
+        });
+
+        try expect.equal(sprite.tint.r, 0);
+        try expect.equal(sprite.tint.g, 255);
+        try expect.equal(sprite.tint.b, 0);
+        try expect.equal(sprite.tint.a, 128);
+    }
+
+    test "callsite override with anonymous nested struct on trait factory" {
+        const RedTintFactory = SpriteVisualFactory.trait(.{
+            .tint = .{ .r = 255, .g = 0, .b = 0, .a = 255 },
+        });
+
+        // Override the trait's tint with anonymous struct at callsite
+        const sprite = RedTintFactory.build(.{
+            .tint = .{ .r = 0, .g = 0, .b = 255, .a = 64 },
+        });
+
+        try expect.equal(sprite.tint.r, 0);
+        try expect.equal(sprite.tint.g, 0);
+        try expect.equal(sprite.tint.b, 255);
+        try expect.equal(sprite.tint.a, 64);
+    }
 };


### PR DESCRIPTION
## Summary

- Fixes nested struct coercion in `Factory.defineFrom()` when loading from `.zon` files
- Anonymous structs like `.{ .r = 255, .g = 255, .b = 255, .a = 255 }` now properly coerce to named struct types like `Color`
- Added struct-to-struct coercion handling in both `FactoryImpl` and `TraitFactoryImpl`
- Added tests for nested struct coercion in `tests/factory_zon_test.zig`

Closes #33

## Test plan

- [x] Run `zig build test` - all unit tests pass
- [x] Run `zig build example` - all example tests pass including new nested struct tests
- [x] Verify new tests cover: basic coercion, overrides, and traits with nested structs

🤖 Generated with [Claude Code](https://claude.com/claude-code)