### PR TITLE
chore(ci): bump Zig 0.15.1 → 0.15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        zig-version: ['0.15.1']
+        zig-version: ['0.15.2']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.15.1'
+          version: '0.15.2'
 
       - name: Install kcov dependencies
         run: |


### PR DESCRIPTION
## Summary

Matches the Zig version downstream consumers (\`labelle-cli\`, \`labelle-assembler\`, \`flying-platform-labelle\`) build against. 0.15.2 is a patch release of 0.15.1 — bug fixes only, no language changes — so no source changes are needed in zspec itself.

## Changes

- \`.github/workflows/ci.yml\`: matrix \`zig-version\` → \`'0.15.2'\`
- \`.github/workflows/coverage.yml\`: \`Setup Zig\` version → \`'0.15.2'\`

## Test plan

- [ ] CI green on Linux / macOS / Windows
- [ ] Coverage job still produces a valid report

🤖 Generated with [Claude Code](https://claude.com/claude-code)