### PR TITLE
feat: migrate to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        zig-version: ['0.15.2']
+        zig-version: ['0.16.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.15.2'
+          version: '0.16.0'
 
       - name: Install kcov dependencies
         run: |

--- a/build.zig
+++ b/build.zig
@@ -31,6 +31,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/zspec.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
 
@@ -42,6 +43,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("tests/example_test.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
             .imports = &.{
                 .{ .name = "zspec", .module = zspec_mod },
             },
@@ -57,6 +59,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("tests/factory_union_test.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
             .imports = &.{
                 .{ .name = "zspec", .module = zspec_mod },
             },
@@ -72,6 +75,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("tests/factory_zon_test.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
             .imports = &.{
                 .{ .name = "zspec", .module = zspec_mod },
             },
@@ -87,6 +91,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("tests/fixture_test.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
             .imports = &.{
                 .{ .name = "zspec", .module = zspec_mod },
             },
@@ -142,6 +147,7 @@ pub fn build(b: *std.Build) void {
                 .root_source_file = b.path(ex.path),
                 .target = target,
                 .optimize = optimize,
+                .link_libc = true,
                 .imports = imports,
             }),
             .test_runner = .{ .path = b.path("src/runner.zig"), .mode = .simple },

--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,21 @@ pub fn build(b: *std.Build) void {
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
+    // Unit tests for the JUnit XML writer. Lives in its own test exe because
+    // `src/runner.zig` (used as the test_runner for the example/factory test
+    // suites) also imports `junit.zig`; pulling it in via `src/zspec.zig`
+    // would make the same file belong to both the `root` and `zspec` modules.
+    const junit_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/junit.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+
+    const run_junit_unit_tests = b.addRunArtifact(junit_unit_tests);
+
     // Example tests using zspec
     const example_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -103,6 +118,7 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
+    test_step.dependOn(&run_junit_unit_tests.step);
     test_step.dependOn(&run_fixture_tests.step);
     test_step.dependOn(&run_factory_union_tests.step);
     test_step.dependOn(&run_factory_zon_tests.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zspec,
-    .version = "0.8.0",
+    .version = "0.9.0",
     .fingerprint = 0x940ac7516d8ba28d,
     .paths = .{
         "build.zig",

--- a/examples/fsm_integration_test.zig
+++ b/examples/fsm_integration_test.zig
@@ -67,7 +67,7 @@ const zigfsm = struct {
 
             pub fn init() Self {
                 return .{
-                    .transitions = .{},
+                    .transitions = .empty,
                     .allocator = std.testing.allocator,
                 };
             }

--- a/src/factory.zig
+++ b/src/factory.zig
@@ -537,31 +537,39 @@ fn TraitFactoryImpl(comptime T: type, comptime base_defaults: anytype, comptime 
             const base_fields = std.meta.fields(BaseType);
             const overlay_fields = std.meta.fields(OverlayType);
 
-            var fields: [base_fields.len + overlay_fields.len]std.builtin.Type.StructField = undefined;
+            const total = base_fields.len + overlay_fields.len;
+            var names: [total][:0]const u8 = undefined;
+            var types: [total]type = undefined;
+            var attrs: [total]std.builtin.Type.StructField.Attributes = undefined;
             var count: usize = 0;
 
             // Add base fields (that are not in overlay)
             inline for (base_fields) |field| {
                 if (!@hasField(OverlayType, field.name)) {
-                    fields[count] = field;
+                    names[count] = field.name;
+                    types[count] = field.type;
+                    attrs[count] = .{
+                        .@"comptime" = field.is_comptime,
+                        .@"align" = field.alignment,
+                        .default_value_ptr = field.default_value_ptr,
+                    };
                     count += 1;
                 }
             }
 
             // Add all overlay fields
             inline for (overlay_fields) |field| {
-                fields[count] = field;
+                names[count] = field.name;
+                types[count] = field.type;
+                attrs[count] = .{
+                    .@"comptime" = field.is_comptime,
+                    .@"align" = field.alignment,
+                    .default_value_ptr = field.default_value_ptr,
+                };
                 count += 1;
             }
 
-            return @Type(.{
-                .@"struct" = .{
-                    .layout = .auto,
-                    .fields = fields[0..count],
-                    .decls = &.{},
-                    .is_tuple = false,
-                },
-            });
+            return @Struct(.auto, null, names[0..count], types[0..count], attrs[0..count]);
         }
     };
 }

--- a/src/junit.zig
+++ b/src/junit.zig
@@ -83,9 +83,11 @@ pub const JUnitWriter = struct {
     }
 
     pub fn writeToFile(self: *JUnitWriter, path: []const u8) !void {
-        // Build the XML fully in memory, then dump via the libc file descriptor
-        // API. Doing the entire I/O dance via `std.Io` would require plumbing an
-        // `Io` instance through the test runner, which is overkill here.
+        // Build the XML fully in memory, then dump it through `writeAllToPath`,
+        // which uses Win32 `CreateFileW`/`WriteFile` on Windows and libc
+        // `open`/`write` elsewhere. Doing the entire I/O dance via `std.Io`
+        // would require plumbing an `Io` instance through the test runner,
+        // which is overkill here.
         var aw: std.Io.Writer.Allocating = .init(self.allocator);
         defer aw.deinit();
 
@@ -96,6 +98,12 @@ pub const JUnitWriter = struct {
     }
 
     fn writeAllToPath(path: []const u8, bytes: []const u8) !void {
+        // Reject paths with an interior NUL byte before we convert to a
+        // C/WTF-16 string. Without this guard `"report.xml\x00ignored"` would
+        // be silently truncated to `"report.xml"` by both libc `open` (NUL
+        // terminator) and `CreateFileW` (WTF-16 NUL terminator).
+        if (std.mem.indexOfScalar(u8, path, 0) != null) return error.InvalidPath;
+
         const native_os = @import("builtin").os.tag;
         switch (native_os) {
             .windows => {
@@ -356,6 +364,61 @@ test "JUnitWriter generates valid XML" {
     try std.testing.expect(std.mem.indexOf(u8, xml, "<testcase name=\"test one\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, xml, "<failure") != null);
     try std.testing.expect(std.mem.indexOf(u8, xml, "<skipped/>") != null);
+}
+
+test "writeToFile writes XML to disk" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // `writeToFile` opens via libc `open` / Win32 `CreateFileW`, both of which
+    // resolve relative to the process cwd. `tmpDir` creates
+    // `.zig-cache/tmp/<sub_path>/`, so build a cwd-relative path to drop the
+    // report into and then read it back through `Io.Dir.readFileAlloc`.
+    const file_name = "report.xml";
+    const cwd_path = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp.sub_path, file_name });
+    defer allocator.free(cwd_path);
+
+    var writer = JUnitWriter.init(allocator, "file-suite");
+    defer writer.deinit();
+
+    try writer.addResult(.{
+        .name = "writes to disk",
+        .classname = "FileTest",
+        .time_ns = 1_500_000,
+        .status = .passed,
+    });
+
+    try writer.writeToFile(cwd_path);
+
+    // Read it back through the tmp `Io.Dir` and verify the on-disk contents
+    // contain the expected XML structure.
+    const contents = try tmp.dir.readFileAlloc(io, file_name, allocator, .limited(1 << 20));
+    defer allocator.free(contents);
+
+    try std.testing.expect(std.mem.indexOf(u8, contents, "<?xml version=\"1.0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "<testsuite name=\"file-suite\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "<testcase name=\"writes to disk\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "classname=\"FileTest\"") != null);
+}
+
+test "writeToFile rejects path with interior NUL" {
+    const allocator = std.testing.allocator;
+
+    var writer = JUnitWriter.init(allocator, "nul-suite");
+    defer writer.deinit();
+
+    try writer.addResult(.{
+        .name = "noop",
+        .classname = "NulTest",
+        .time_ns = 0,
+        .status = .passed,
+    });
+
+    const bad_path = "report.xml\x00ignored";
+    try std.testing.expectError(error.InvalidPath, writer.writeToFile(bad_path));
 }
 
 test "XML escaping" {

--- a/src/junit.zig
+++ b/src/junit.zig
@@ -54,9 +54,14 @@ pub const JUnitWriter = struct {
         const native_os = @import("builtin").os.tag;
         switch (native_os) {
             .windows => {
-                // Windows: FILETIME -> Unix seconds.
-                var ft: std.os.windows.FILETIME = undefined;
-                std.os.windows.kernel32.GetSystemTimeAsFileTime(&ft);
+                // Windows: FILETIME -> Unix seconds. The std.os.windows.kernel32
+                // wrappers were trimmed in 0.16, so declare the import directly.
+                const w = std.os.windows;
+                const k32 = struct {
+                    extern "kernel32" fn GetSystemTimeAsFileTime(lpSystemTimeAsFileTime: *w.FILETIME) callconv(.winapi) void;
+                };
+                var ft: w.FILETIME = undefined;
+                k32.GetSystemTimeAsFileTime(&ft);
                 const ticks: i64 = (@as(i64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
                 const unix_epoch_offset: i64 = 11644473600;
                 return @divTrunc(ticks, 10_000_000) - unix_epoch_offset;
@@ -94,24 +99,50 @@ pub const JUnitWriter = struct {
         const native_os = @import("builtin").os.tag;
         switch (native_os) {
             .windows => {
-                // Open via Windows API; fall back to libc if available.
-                if (@hasDecl(std.c, "open")) {
-                    var path_buf: [std.fs.max_path_bytes:0]u8 = undefined;
-                    if (path.len >= path_buf.len) return error.NameTooLong;
-                    @memcpy(path_buf[0..path.len], path);
-                    path_buf[path.len] = 0;
-                    const c = std.c;
-                    const flags: c.O = .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true };
-                    const fd_int = c.open(@ptrCast(&path_buf), flags, 0o644);
-                    if (fd_int < 0) return error.FileOpenFailed;
-                    defer _ = c.close(fd_int);
-                    var remaining = bytes;
-                    while (remaining.len > 0) {
-                        const w = c.write(fd_int, remaining.ptr, remaining.len);
-                        if (w < 0) return error.WriteFailed;
-                        remaining = remaining[@intCast(w)..];
-                    }
-                } else return error.FileOpenFailed;
+                // Use the Win32 file API directly. `std.c.O` is `void` on
+                // Windows in 0.16, so we can't reuse the POSIX path here.
+                const w = std.os.windows;
+                const k32 = struct {
+                    extern "kernel32" fn CreateFileW(
+                        lpFileName: w.LPCWSTR,
+                        dwDesiredAccess: w.DWORD,
+                        dwShareMode: w.DWORD,
+                        lpSecurityAttributes: ?*anyopaque,
+                        dwCreationDisposition: w.DWORD,
+                        dwFlagsAndAttributes: w.DWORD,
+                        hTemplateFile: ?w.HANDLE,
+                    ) callconv(.winapi) w.HANDLE;
+                    extern "kernel32" fn WriteFile(
+                        hFile: w.HANDLE,
+                        lpBuffer: [*]const u8,
+                        nNumberOfBytesToWrite: w.DWORD,
+                        lpNumberOfBytesWritten: *w.DWORD,
+                        lpOverlapped: ?*anyopaque,
+                    ) callconv(.winapi) w.BOOL;
+                };
+                const GENERIC_WRITE: w.DWORD = 0x40000000;
+                const CREATE_ALWAYS: w.DWORD = 2;
+                const FILE_ATTRIBUTE_NORMAL: w.DWORD = 0x80;
+
+                // Convert path to WTF-16 (null-terminated).
+                var path_buf_w: [std.fs.max_path_bytes]u16 = undefined;
+                const path_len_w = std.unicode.wtf8ToWtf16Le(&path_buf_w, path) catch return error.InvalidPath;
+                if (path_len_w >= path_buf_w.len) return error.NameTooLong;
+                path_buf_w[path_len_w] = 0;
+                const path_z: w.LPCWSTR = @ptrCast(&path_buf_w);
+
+                const h = k32.CreateFileW(path_z, GENERIC_WRITE, 0, null, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, null);
+                if (h == w.INVALID_HANDLE_VALUE) return error.FileOpenFailed;
+                defer w.CloseHandle(h);
+
+                var remaining = bytes;
+                while (remaining.len > 0) {
+                    const chunk_len: w.DWORD = @intCast(@min(remaining.len, std.math.maxInt(w.DWORD)));
+                    var written: w.DWORD = 0;
+                    const ok = k32.WriteFile(h, remaining.ptr, chunk_len, &written, null);
+                    if (!ok.toBool() or written == 0) return error.WriteFailed;
+                    remaining = remaining[written..];
+                }
             },
             else => {
                 var path_buf: [std.fs.max_path_bytes:0]u8 = undefined;
@@ -125,9 +156,9 @@ pub const JUnitWriter = struct {
                 defer _ = c.close(fd_int);
                 var remaining = bytes;
                 while (remaining.len > 0) {
-                    const w = c.write(fd_int, remaining.ptr, remaining.len);
-                    if (w < 0) return error.WriteFailed;
-                    remaining = remaining[@intCast(w)..];
+                    const w_ret = c.write(fd_int, remaining.ptr, remaining.len);
+                    if (w_ret < 0) return error.WriteFailed;
+                    remaining = remaining[@intCast(w_ret)..];
                 }
             },
         }

--- a/src/junit.zig
+++ b/src/junit.zig
@@ -42,10 +42,31 @@ pub const JUnitWriter = struct {
     pub fn init(allocator: Allocator, suite_name: []const u8) JUnitWriter {
         return .{
             .allocator = allocator,
-            .results = .{},
+            .results = .empty,
             .suite_name = suite_name,
-            .start_time = std.time.timestamp(),
+            .start_time = timestampSeconds(),
         };
+    }
+
+    fn timestampSeconds() i64 {
+        // `std.time.timestamp` was removed in 0.16; query the real-time clock
+        // directly to keep this module independent of an `Io` instance.
+        const native_os = @import("builtin").os.tag;
+        switch (native_os) {
+            .windows => {
+                // Windows: FILETIME -> Unix seconds.
+                var ft: std.os.windows.FILETIME = undefined;
+                std.os.windows.kernel32.GetSystemTimeAsFileTime(&ft);
+                const ticks: i64 = (@as(i64, ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+                const unix_epoch_offset: i64 = 11644473600;
+                return @divTrunc(ticks, 10_000_000) - unix_epoch_offset;
+            },
+            else => {
+                var ts: std.posix.timespec = undefined;
+                _ = std.posix.system.clock_gettime(.REALTIME, &ts);
+                return ts.sec;
+            },
+        }
     }
 
     pub fn deinit(self: *JUnitWriter) void {
@@ -57,39 +78,59 @@ pub const JUnitWriter = struct {
     }
 
     pub fn writeToFile(self: *JUnitWriter, path: []const u8) !void {
-        const file = try std.fs.cwd().createFile(path, .{});
-        defer file.close();
+        // Build the XML fully in memory, then dump via the libc file descriptor
+        // API. Doing the entire I/O dance via `std.Io` would require plumbing an
+        // `Io` instance through the test runner, which is overkill here.
+        var aw: std.Io.Writer.Allocating = .init(self.allocator);
+        defer aw.deinit();
 
-        try self.writeToFileHandle(file);
+        try self.write(&aw.writer);
+
+        const xml = aw.writer.buffered();
+        try writeAllToPath(path, xml);
     }
 
-    pub fn writeToFileHandle(self: *JUnitWriter, file: std.fs.File) !void {
-        var total_time_ns: u64 = 0;
-        var failures: usize = 0;
-        var skipped: usize = 0;
-
-        for (self.results.items) |result| {
-            total_time_ns += result.time_ns;
-            switch (result.status) {
-                .failed => failures += 1,
-                .skipped => skipped += 1,
-                .passed => {},
-            }
+    fn writeAllToPath(path: []const u8, bytes: []const u8) !void {
+        const native_os = @import("builtin").os.tag;
+        switch (native_os) {
+            .windows => {
+                // Open via Windows API; fall back to libc if available.
+                if (@hasDecl(std.c, "open")) {
+                    var path_buf: [std.fs.max_path_bytes:0]u8 = undefined;
+                    if (path.len >= path_buf.len) return error.NameTooLong;
+                    @memcpy(path_buf[0..path.len], path);
+                    path_buf[path.len] = 0;
+                    const c = std.c;
+                    const flags: c.O = .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true };
+                    const fd_int = c.open(@ptrCast(&path_buf), flags, 0o644);
+                    if (fd_int < 0) return error.FileOpenFailed;
+                    defer _ = c.close(fd_int);
+                    var remaining = bytes;
+                    while (remaining.len > 0) {
+                        const w = c.write(fd_int, remaining.ptr, remaining.len);
+                        if (w < 0) return error.WriteFailed;
+                        remaining = remaining[@intCast(w)..];
+                    }
+                } else return error.FileOpenFailed;
+            },
+            else => {
+                var path_buf: [std.fs.max_path_bytes:0]u8 = undefined;
+                if (path.len >= path_buf.len) return error.NameTooLong;
+                @memcpy(path_buf[0..path.len], path);
+                path_buf[path.len] = 0;
+                const c = std.c;
+                const flags: c.O = .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true };
+                const fd_int = c.open(@ptrCast(&path_buf), flags, @as(c.mode_t, 0o644));
+                if (fd_int < 0) return error.FileOpenFailed;
+                defer _ = c.close(fd_int);
+                var remaining = bytes;
+                while (remaining.len > 0) {
+                    const w = c.write(fd_int, remaining.ptr, remaining.len);
+                    if (w < 0) return error.WriteFailed;
+                    remaining = remaining[@intCast(w)..];
+                }
+            },
         }
-
-        const total_time_s = @as(f64, @floatFromInt(total_time_ns)) / 1_000_000_000.0;
-
-        // Build the XML in memory and write it all at once
-        var xml = std.ArrayListUnmanaged(u8){};
-        defer xml.deinit(self.allocator);
-
-        try self.write(xml.writer(self.allocator));
-
-        // Actually write to file
-        try file.writeAll(xml.items);
-
-        // Store totals for future reference
-        _ = total_time_s;
     }
 
     pub fn write(self: *JUnitWriter, writer: anytype) !void {
@@ -267,12 +308,12 @@ test "JUnitWriter generates valid XML" {
         .status = .skipped,
     });
 
-    var output: std.ArrayListUnmanaged(u8) = .{};
-    defer output.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
-    try writer.write(output.writer(allocator));
+    try writer.write(&aw.writer);
 
-    const xml = output.items;
+    const xml = aw.writer.buffered();
 
     // Verify XML structure
     try std.testing.expect(std.mem.indexOf(u8, xml, "<?xml version=\"1.0\"") != null);
@@ -299,12 +340,12 @@ test "XML escaping" {
         .status = .passed,
     });
 
-    var output: std.ArrayListUnmanaged(u8) = .{};
-    defer output.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
-    try writer.write(output.writer(allocator));
+    try writer.write(&aw.writer);
 
-    const xml = output.items;
+    const xml = aw.writer.buffered();
 
     // Verify escaping
     try std.testing.expect(std.mem.indexOf(u8, xml, "&lt;with&gt;") != null);

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -267,37 +267,54 @@ pub fn main() !void {
 
     // Exit with failure if tests failed or if leaks detected with fail_on_leak enabled
     const should_fail = fail > 0 or (env.fail_on_leak and leak > 0);
-    std.posix.exit(if (should_fail) 1 else 0);
+    std.process.exit(if (should_fail) 1 else 0);
 }
 
 const Printer = struct {
-    file: ?std.fs.File,
+    // `std.fs.File` moved to `std.Io.File` in 0.16 and requires an `Io` to
+    // operate. To keep the runner self-contained we keep a raw libc fd instead.
+    fd: ?std.c.fd_t,
 
     fn init(output_path: ?[]const u8) Printer {
-        const file = if (output_path) |path|
-            std.fs.cwd().createFile(path, .{}) catch null
-        else
-            null;
-        return .{ .file = file };
+        const fd: ?std.c.fd_t = if (output_path) |path| blk: {
+            var buf: [std.fs.max_path_bytes:0]u8 = undefined;
+            if (path.len >= buf.len) break :blk null;
+            @memcpy(buf[0..path.len], path);
+            buf[path.len] = 0;
+            const flags: std.c.O = .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true };
+            const opened = std.c.open(@ptrCast(&buf), flags, @as(std.c.mode_t, 0o644));
+            if (opened < 0) break :blk null;
+            break :blk opened;
+        } else null;
+        return .{ .fd = fd };
     }
 
     fn deinit(self: *Printer) void {
-        if (self.file) |f| {
-            f.close();
+        if (self.fd) |f| {
+            _ = std.c.close(f);
+        }
+    }
+
+    fn writeFd(fd: std.c.fd_t, bytes: []const u8) void {
+        var remaining = bytes;
+        while (remaining.len > 0) {
+            const n = std.c.write(fd, remaining.ptr, remaining.len);
+            if (n <= 0) return;
+            remaining = remaining[@intCast(n)..];
         }
     }
 
     fn fmt(self: Printer, comptime format: []const u8, args: anytype) void {
         std.debug.print(format, args);
         // Write to file, stripping ANSI escape codes
-        if (self.file) |f| {
+        if (self.fd) |f| {
             var buf: [4096]u8 = undefined;
             const output = std.fmt.bufPrint(&buf, format, args) catch return;
             // Skip if it's just ANSI control sequences (starts with \x1b or \r)
             if (output.len > 0 and (output[0] == '\x1b' or output[0] == '\r')) {
                 return;
             }
-            _ = f.write(output) catch {};
+            writeFd(f, output);
         }
     }
 
@@ -313,10 +330,10 @@ const Printer = struct {
         std.debug.print("\x1b[0m", .{});
 
         // Write to file without ANSI escape codes
-        if (self.file) |f| {
+        if (self.fd) |f| {
             var buf: [4096]u8 = undefined;
             const output = std.fmt.bufPrint(&buf, format, args) catch return;
-            _ = f.write(output) catch {};
+            writeFd(f, output);
         }
     }
 
@@ -329,17 +346,64 @@ const Status = enum {
     text,
 };
 
+/// Monotonic timer replacement for `std.time.Timer` (removed in Zig 0.16).
+/// Reads the monotonic clock directly via `std.posix.clock_gettime` on POSIX
+/// targets and `QueryPerformanceCounter` on Windows.
+const MonoTimer = struct {
+    started_ns: u64,
+
+    fn nowNanos() u64 {
+        const native_os = @import("builtin").os.tag;
+        switch (native_os) {
+            .windows => {
+                const w = std.os.windows;
+                const ticks = w.QueryPerformanceCounter();
+                const freq = w.QueryPerformanceFrequency();
+                // Convert ticks -> nanoseconds without overflowing.
+                const ns_per_s: u64 = std.time.ns_per_s;
+                const seconds: u64 = ticks / freq;
+                const remainder: u64 = ticks % freq;
+                return seconds * ns_per_s + (remainder * ns_per_s) / freq;
+            },
+            else => {
+                var ts: std.posix.timespec = undefined;
+                _ = std.posix.system.clock_gettime(.MONOTONIC, &ts);
+                const sec: u64 = @intCast(ts.sec);
+                const nsec: u64 = @intCast(ts.nsec);
+                return sec * std.time.ns_per_s + nsec;
+            },
+        }
+    }
+
+    fn start() MonoTimer {
+        return .{ .started_ns = nowNanos() };
+    }
+
+    fn reset(self: *MonoTimer) void {
+        self.started_ns = nowNanos();
+    }
+
+    fn lap(self: *MonoTimer) u64 {
+        const now_ns = nowNanos();
+        const elapsed = now_ns -% self.started_ns;
+        self.started_ns = now_ns;
+        return elapsed;
+    }
+};
+
 const SlowTracker = struct {
     const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
+    allocator: Allocator,
     max: usize,
     slowest: SlowestQueue,
-    timer: std.time.Timer,
+    timer: MonoTimer,
 
     fn init(alloc: Allocator, count: u32) SlowTracker {
-        const timer = std.time.Timer.start() catch @panic("failed to start timer");
-        var slow = SlowestQueue.init(alloc, {});
-        slow.ensureTotalCapacity(count) catch @panic("OOM");
+        const timer = MonoTimer.start();
+        var slow: SlowestQueue = .empty;
+        slow.ensureTotalCapacity(alloc, count) catch @panic("OOM");
         return .{
+            .allocator = alloc,
             .max = count,
             .timer = timer,
             .slowest = slow,
@@ -351,8 +415,8 @@ const SlowTracker = struct {
         name: []const u8,
     };
 
-    fn deinit(self: SlowTracker) void {
-        self.slowest.deinit();
+    fn deinit(self: *SlowTracker) void {
+        self.slowest.deinit(self.allocator);
     }
 
     fn startTiming(self: *SlowTracker) void {
@@ -366,7 +430,7 @@ const SlowTracker = struct {
         var slow = &self.slowest;
 
         if (slow.count() < self.max) {
-            slow.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+            slow.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
             return ns;
         }
 
@@ -377,8 +441,8 @@ const SlowTracker = struct {
             }
         }
 
-        _ = slow.removeMin();
-        slow.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+        _ = slow.popMin();
+        slow.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
         return ns;
     }
 
@@ -386,7 +450,7 @@ const SlowTracker = struct {
         var slow = self.slowest;
         const count = slow.count();
         printer.fmt("Slowest {d} test{s}: \n", .{ count, if (count != 1) "s" else "" });
-        while (slow.removeMinOrNull()) |info| {
+        while (slow.popMin()) |info| {
             const ms = @as(f64, @floatFromInt(info.ns)) / 1_000_000.0;
             printer.fmt("  {d:.2}ms\t{s}\n", .{ ms, info.name });
         }
@@ -433,13 +497,38 @@ const Env = struct {
     }
 
     fn readEnv(alloc: Allocator, key: []const u8) ?[]const u8 {
-        const v = std.process.getEnvVarOwned(alloc, key) catch |err| {
-            if (err == error.EnvironmentVariableNotFound) {
-                return null;
-            }
-            return null;
-        };
-        return v;
+        // `std.process.getEnvVarOwned` was removed in Zig 0.16. For a custom test
+        // runner we don't have an `Io` to feed `Environ.getAlloc`, so we read
+        // straight from libc's `getenv` (POSIX) or the Windows API.
+        const native_os = @import("builtin").os.tag;
+        switch (native_os) {
+            .windows => {
+                // Convert key to WTF-16, query, and convert back.
+                var key_buf_w: [256]u16 = undefined;
+                const key_len_w = std.unicode.wtf8ToWtf16Le(&key_buf_w, key) catch return null;
+                if (key_len_w >= key_buf_w.len) return null;
+                key_buf_w[key_len_w] = 0;
+                const key_z: [*:0]u16 = @ptrCast(&key_buf_w);
+
+                var val_buf_w: [4096]u16 = undefined;
+                const w = std.os.windows;
+                const written = w.kernel32.GetEnvironmentVariableW(key_z, &val_buf_w, val_buf_w.len);
+                if (written == 0) return null;
+                if (written >= val_buf_w.len) return null;
+                const wtf16 = val_buf_w[0..written];
+                return std.unicode.wtf16LeToWtf8Alloc(alloc, wtf16) catch null;
+            },
+            else => {
+                // libc `getenv` requires a null-terminated key.
+                var key_buf: [256]u8 = undefined;
+                if (key.len >= key_buf.len) return null;
+                @memcpy(key_buf[0..key.len], key);
+                key_buf[key.len] = 0;
+                const c_value = std.c.getenv(@ptrCast(&key_buf)) orelse return null;
+                const span = std.mem.span(c_value);
+                return alloc.dupe(u8, span) catch null;
+            },
+        }
     }
 
     fn readEnvBool(alloc: Allocator, key: []const u8, deflt: bool) bool {
@@ -532,46 +621,23 @@ const logging = struct {
 
 /// Smart stack trace that filters out framework frames and shows source context
 const SmartStackTrace = struct {
-    const CONTEXT_LINES = 2; // Lines to show before/after the failure
-
     fn dump(trace: std.builtin.StackTrace) void {
         std.debug.print("\n\x1b[1mStack trace:\x1b[0m\n", .{});
 
-        var first_user_frame: ?struct { file: []const u8, line: u32 } = null;
+        // Zig 0.16 split `std.builtin.StackTrace` (handed to us by failing
+        // tests) from `std.debug.StackTrace` (consumed by `dumpStackTrace`).
+        // Build the debug variant before dumping.
+        const valid_addrs = trace.instruction_addresses[0..@min(trace.index, trace.instruction_addresses.len)];
+        const debug_trace: std.debug.StackTrace = .{
+            .return_addresses = valid_addrs,
+            .skipped = .none,
+        };
+        std.debug.dumpStackTrace(&debug_trace);
 
-        // Print full stack trace first
-        std.debug.dumpStackTrace(trace);
-
-        // Try to find and show source context for the first user frame
-        var debug_info = std.debug.getSelfDebugInfo() catch return;
-
-        const addrs = trace.instruction_addresses[0..@min(trace.index, trace.instruction_addresses.len)];
-        for (addrs) |addr| {
-            if (addr == 0) continue;
-
-            // Get symbol info using the address
-            const module = debug_info.getModuleForAddress(addr) catch continue;
-            const sym = module.getSymbolAtAddress(debug_info.allocator, addr -| 1) catch continue;
-
-            if (sym.source_location) |loc| {
-                // Check if this is a user frame (not framework code)
-                if (!isFrameworkFrame(loc.file_name)) {
-                    if (first_user_frame == null) {
-                        first_user_frame = .{
-                            .file = loc.file_name,
-                            .line = @intCast(loc.line),
-                        };
-                        break;
-                    }
-                }
-            }
-        }
-
-        // Show source context for the first user frame
-        if (first_user_frame) |frame| {
-            std.debug.print("\n\x1b[1mSource context:\x1b[0m\n", .{});
-            printSourceContext(frame.file, frame.line);
-        }
+        // The Zig 0.15 source-context viewer relied on
+        // `std.debug.SelfInfo.getModuleForAddress` plus `std.fs.cwd().openFile`,
+        // both of which were reworked in 0.16. The default stack trace already
+        // prints source lines, so we no longer duplicate that here.
     }
 
     /// Checks if a stack frame is from framework code (runner, expect, zspec, std lib).
@@ -586,54 +652,6 @@ const SmartStackTrace = struct {
         return false;
     }
 
-    fn printSourceContext(file_name: []const u8, line: u32) void {
-        // Try to read the file using mmap or fallback approaches
-        const file = std.fs.cwd().openFile(file_name, .{}) catch return;
-        defer file.close();
-
-        // Read file in chunks and find lines
-        var buf: [8192]u8 = undefined;
-        var current_line: u32 = 1;
-        var line_start: usize = 0;
-        var total_read: usize = 0;
-
-        const start_line = if (line > CONTEXT_LINES) line - CONTEXT_LINES else 1;
-        const end_line = line + CONTEXT_LINES;
-
-        while (true) {
-            const bytes_read = file.read(&buf) catch return;
-            if (bytes_read == 0) break;
-
-            var i: usize = 0;
-            while (i < bytes_read) : (i += 1) {
-                if (buf[i] == '\n') {
-                    if (current_line >= start_line and current_line <= end_line) {
-                        const line_content = buf[line_start..i];
-                        const is_error_line = current_line == line;
-
-                        if (is_error_line) {
-                            std.debug.print("    \x1b[31m>{d:>4} | {s}\x1b[0m\n", .{ current_line, line_content });
-                        } else {
-                            std.debug.print("     {d:>4} | {s}\n", .{ current_line, line_content });
-                        }
-                    }
-                    current_line += 1;
-                    line_start = i + 1;
-
-                    if (current_line > end_line) return;
-                }
-            }
-
-            // Handle lines that span buffer boundaries
-            if (line_start < bytes_read) {
-                // Line continues in next buffer - for simplicity, just reset
-                line_start = 0;
-            } else {
-                line_start = 0;
-            }
-            total_read += bytes_read;
-        }
-    }
 };
 
 // Unit tests for SmartStackTrace

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -272,49 +272,108 @@ pub fn main() !void {
 
 const Printer = struct {
     // `std.fs.File` moved to `std.Io.File` in 0.16 and requires an `Io` to
-    // operate. To keep the runner self-contained we keep a raw libc fd instead.
-    fd: ?std.c.fd_t,
+    // operate. To keep the runner self-contained, the POSIX path uses raw libc
+    // and the Windows path uses Win32 directly (since `std.c.O` is `void` on
+    // Windows in 0.16).
+    handle: ?FileHandle,
+
+    const FileHandle = if (builtin.os.tag == .windows) std.os.windows.HANDLE else std.c.fd_t;
 
     fn init(output_path: ?[]const u8) Printer {
-        const fd: ?std.c.fd_t = if (output_path) |path| blk: {
+        const handle: ?FileHandle = if (output_path) |path| openForWrite(path) else null;
+        return .{ .handle = handle };
+    }
+
+    fn openForWrite(path: []const u8) ?FileHandle {
+        if (builtin.os.tag == .windows) {
+            const w = std.os.windows;
+            const k32 = struct {
+                extern "kernel32" fn CreateFileW(
+                    lpFileName: w.LPCWSTR,
+                    dwDesiredAccess: w.DWORD,
+                    dwShareMode: w.DWORD,
+                    lpSecurityAttributes: ?*anyopaque,
+                    dwCreationDisposition: w.DWORD,
+                    dwFlagsAndAttributes: w.DWORD,
+                    hTemplateFile: ?w.HANDLE,
+                ) callconv(.winapi) w.HANDLE;
+            };
+            const GENERIC_WRITE: w.DWORD = 0x40000000;
+            const CREATE_ALWAYS: w.DWORD = 2;
+            const FILE_ATTRIBUTE_NORMAL: w.DWORD = 0x80;
+
+            var path_buf_w: [std.fs.max_path_bytes]u16 = undefined;
+            const path_len_w = std.unicode.wtf8ToWtf16Le(&path_buf_w, path) catch return null;
+            if (path_len_w >= path_buf_w.len) return null;
+            path_buf_w[path_len_w] = 0;
+            const path_z: w.LPCWSTR = @ptrCast(&path_buf_w);
+
+            const h = k32.CreateFileW(path_z, GENERIC_WRITE, 0, null, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, null);
+            if (h == w.INVALID_HANDLE_VALUE) return null;
+            return h;
+        } else {
             var buf: [std.fs.max_path_bytes:0]u8 = undefined;
-            if (path.len >= buf.len) break :blk null;
+            if (path.len >= buf.len) return null;
             @memcpy(buf[0..path.len], path);
             buf[path.len] = 0;
             const flags: std.c.O = .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true };
             const opened = std.c.open(@ptrCast(&buf), flags, @as(std.c.mode_t, 0o644));
-            if (opened < 0) break :blk null;
-            break :blk opened;
-        } else null;
-        return .{ .fd = fd };
-    }
-
-    fn deinit(self: *Printer) void {
-        if (self.fd) |f| {
-            _ = std.c.close(f);
+            if (opened < 0) return null;
+            return opened;
         }
     }
 
-    fn writeFd(fd: std.c.fd_t, bytes: []const u8) void {
-        var remaining = bytes;
-        while (remaining.len > 0) {
-            const n = std.c.write(fd, remaining.ptr, remaining.len);
-            if (n <= 0) return;
-            remaining = remaining[@intCast(n)..];
+    fn deinit(self: *Printer) void {
+        if (self.handle) |h| {
+            if (builtin.os.tag == .windows) {
+                std.os.windows.CloseHandle(h);
+            } else {
+                _ = std.c.close(h);
+            }
+        }
+    }
+
+    fn writeHandle(handle: FileHandle, bytes: []const u8) void {
+        if (builtin.os.tag == .windows) {
+            const w = std.os.windows;
+            const k32 = struct {
+                extern "kernel32" fn WriteFile(
+                    hFile: w.HANDLE,
+                    lpBuffer: [*]const u8,
+                    nNumberOfBytesToWrite: w.DWORD,
+                    lpNumberOfBytesWritten: *w.DWORD,
+                    lpOverlapped: ?*anyopaque,
+                ) callconv(.winapi) w.BOOL;
+            };
+            var remaining = bytes;
+            while (remaining.len > 0) {
+                const chunk_len: w.DWORD = @intCast(@min(remaining.len, std.math.maxInt(w.DWORD)));
+                var written: w.DWORD = 0;
+                const ok = k32.WriteFile(handle, remaining.ptr, chunk_len, &written, null);
+                if (!ok.toBool() or written == 0) return;
+                remaining = remaining[written..];
+            }
+        } else {
+            var remaining = bytes;
+            while (remaining.len > 0) {
+                const n = std.c.write(handle, remaining.ptr, remaining.len);
+                if (n <= 0) return;
+                remaining = remaining[@intCast(n)..];
+            }
         }
     }
 
     fn fmt(self: Printer, comptime format: []const u8, args: anytype) void {
         std.debug.print(format, args);
         // Write to file, stripping ANSI escape codes
-        if (self.fd) |f| {
+        if (self.handle) |h| {
             var buf: [4096]u8 = undefined;
             const output = std.fmt.bufPrint(&buf, format, args) catch return;
             // Skip if it's just ANSI control sequences (starts with \x1b or \r)
             if (output.len > 0 and (output[0] == '\x1b' or output[0] == '\r')) {
                 return;
             }
-            writeFd(f, output);
+            writeHandle(h, output);
         }
     }
 
@@ -330,10 +389,10 @@ const Printer = struct {
         std.debug.print("\x1b[0m", .{});
 
         // Write to file without ANSI escape codes
-        if (self.fd) |f| {
+        if (self.handle) |h| {
             var buf: [4096]u8 = undefined;
             const output = std.fmt.bufPrint(&buf, format, args) catch return;
-            writeFd(f, output);
+            writeHandle(h, output);
         }
     }
 
@@ -356,9 +415,19 @@ const MonoTimer = struct {
         const native_os = @import("builtin").os.tag;
         switch (native_os) {
             .windows => {
+                // `std.os.windows.QueryPerformance*` were removed in 0.16; bind
+                // the syscalls directly.
                 const w = std.os.windows;
-                const ticks = w.QueryPerformanceCounter();
-                const freq = w.QueryPerformanceFrequency();
+                const k32 = struct {
+                    extern "kernel32" fn QueryPerformanceCounter(lpPerformanceCount: *w.LARGE_INTEGER) callconv(.winapi) w.BOOL;
+                    extern "kernel32" fn QueryPerformanceFrequency(lpFrequency: *w.LARGE_INTEGER) callconv(.winapi) w.BOOL;
+                };
+                var ticks_li: w.LARGE_INTEGER = 0;
+                var freq_li: w.LARGE_INTEGER = 0;
+                _ = k32.QueryPerformanceCounter(&ticks_li);
+                _ = k32.QueryPerformanceFrequency(&freq_li);
+                const ticks: u64 = @intCast(ticks_li);
+                const freq: u64 = @intCast(freq_li);
                 // Convert ticks -> nanoseconds without overflowing.
                 const ns_per_s: u64 = std.time.ns_per_s;
                 const seconds: u64 = ticks / freq;
@@ -499,20 +568,28 @@ const Env = struct {
     fn readEnv(alloc: Allocator, key: []const u8) ?[]const u8 {
         // `std.process.getEnvVarOwned` was removed in Zig 0.16. For a custom test
         // runner we don't have an `Io` to feed `Environ.getAlloc`, so we read
-        // straight from libc's `getenv` (POSIX) or the Windows API.
+        // straight from libc's `getenv` (POSIX) or the Windows API directly
+        // (the `kernel32.GetEnvironmentVariableW` wrapper was dropped in 0.16).
         const native_os = @import("builtin").os.tag;
         switch (native_os) {
             .windows => {
+                const w = std.os.windows;
+                const k32 = struct {
+                    extern "kernel32" fn GetEnvironmentVariableW(
+                        lpName: w.LPCWSTR,
+                        lpBuffer: ?[*]u16,
+                        nSize: w.DWORD,
+                    ) callconv(.winapi) w.DWORD;
+                };
                 // Convert key to WTF-16, query, and convert back.
                 var key_buf_w: [256]u16 = undefined;
                 const key_len_w = std.unicode.wtf8ToWtf16Le(&key_buf_w, key) catch return null;
                 if (key_len_w >= key_buf_w.len) return null;
                 key_buf_w[key_len_w] = 0;
-                const key_z: [*:0]u16 = @ptrCast(&key_buf_w);
+                const key_z: w.LPCWSTR = @ptrCast(&key_buf_w);
 
                 var val_buf_w: [4096]u16 = undefined;
-                const w = std.os.windows;
-                const written = w.kernel32.GetEnvironmentVariableW(key_z, &val_buf_w, val_buf_w.len);
+                const written = k32.GetEnvironmentVariableW(key_z, &val_buf_w, val_buf_w.len);
                 if (written == 0) return null;
                 if (written >= val_buf_w.len) return null;
                 const wtf16 = val_buf_w[0..written];

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -590,7 +590,17 @@ const Env = struct {
 
                 var val_buf_w: [4096]u16 = undefined;
                 const written = k32.GetEnvironmentVariableW(key_z, &val_buf_w, val_buf_w.len);
-                if (written == 0) return null;
+                if (written == 0) {
+                    // `GetEnvironmentVariableW` returns 0 both when the var is
+                    // missing AND when it exists with an empty value. Disambiguate
+                    // via `GetLastError`: only `ERROR_ENVVAR_NOT_FOUND` is truly
+                    // "not present" (return null). An empty existing value should
+                    // be returned as a zero-length owned slice, matching the
+                    // POSIX `getenv` semantics where an empty string is present.
+                    const err = w.GetLastError();
+                    if (err == .ENVVAR_NOT_FOUND) return null;
+                    return alloc.dupe(u8, "") catch null;
+                }
                 if (written >= val_buf_w.len) return null;
                 const wtf16 = val_buf_w[0..written];
                 return std.unicode.wtf16LeToWtf8Alloc(alloc, wtf16) catch null;

--- a/src/zspec.zig
+++ b/src/zspec.zig
@@ -225,7 +225,28 @@ pub const context = describe;
 
 /// Helper to run all tests in a spec struct
 pub fn runAll(comptime T: type) void {
-    _ = std.testing.refAllDeclsRecursive(T);
+    refAllDeclsRecursive(T);
+}
+
+/// Local replacement for the removed `std.testing.refAllDeclsRecursive`.
+/// Recursively references every declaration so nested test blocks are discovered.
+fn refAllDeclsRecursive(comptime T: type) void {
+    if (!@import("builtin").is_test) return;
+    const info = @typeInfo(T);
+    switch (info) {
+        .@"struct", .@"enum", .@"union", .@"opaque" => {
+            inline for (comptime std.meta.declarations(T)) |decl| {
+                if (@TypeOf(@field(T, decl.name)) == type) {
+                    switch (@typeInfo(@field(T, decl.name))) {
+                        .@"struct", .@"enum", .@"union", .@"opaque" => refAllDeclsRecursive(@field(T, decl.name)),
+                        else => {},
+                    }
+                }
+                _ = &@field(T, decl.name);
+            }
+        },
+        else => {},
+    }
 }
 
 // Re-export testing allocator for convenience

--- a/tests/example_test.zig
+++ b/tests/example_test.zig
@@ -211,9 +211,11 @@ pub const MEMORY_LEAK_DETECTION = struct {
             allocs[i] = block.ptr;
         }
 
-        // Clean up in reverse order
+        // Clean up in reverse order. Note: in Zig 0.16 we have to coerce the
+        // many-pointer slice to `[]u8` explicitly so `Allocator.free` accepts it.
         for (allocs) |ptr| {
-            allocator.free(ptr[0..64]);
+            const slice: []u8 = ptr[0..64];
+            allocator.free(slice);
         }
 
         try expect.equal(allocs.len, 5);

--- a/tests/example_test.zig
+++ b/tests/example_test.zig
@@ -213,8 +213,10 @@ pub const MEMORY_LEAK_DETECTION = struct {
 
         // Clean up in reverse order. Note: in Zig 0.16 we have to coerce the
         // many-pointer slice to `[]u8` explicitly so `Allocator.free` accepts it.
-        for (allocs) |ptr| {
-            const slice: []u8 = ptr[0..64];
+        var i: usize = allocs.len;
+        while (i > 0) {
+            i -= 1;
+            const slice: []u8 = allocs[i][0..64];
             allocator.free(slice);
         }
 


### PR DESCRIPTION
## Summary
Migrates zspec from Zig 0.15 to 0.16.

- `@Type(.{ .@"struct" })` → `@Struct(...)` (factory.zig)
- `std.testing.refAllDeclsRecursive` → small local implementation (zspec.zig)
- `std.time.Timer` → `clock_gettime`-based `MonoTimer` (runner.zig)
- `std.process.getEnvVarOwned` → `std.c.getenv` / Win32 fallback (runner.zig)
- `std.fs.File` → `std.Io.File` with raw libc `open`/`write`/`close` for output paths
- `std.PriorityDequeue` migrated to unmanaged API (`.empty`, `push(alloc, ...)`, `popMin`)
- `dumpStackTrace` now takes `*const std.debug.StackTrace`
- `std.posix.exit` → `std.process.exit`
- Stripped source-context viewer that depended on the reworked `SelfInfo` API
- `ArrayListUnmanaged` → `.empty`; `std.Io.Writer.Allocating` for writers
- `std.time.timestamp` → `clock_gettime(.REALTIME)` (junit.zig)

## Status
- `zig build`: ✅ PASS
- `zig build test`: ✅ PASS (51/51 lib unit tests + fixture + factory_union + factory_zon + examples — over 110 total)