### PR TITLE
fix(runner): init std.testing.io_instance — fixes #44

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -120,12 +120,34 @@ pub fn build(b: *std.Build) void {
 
     const run_fixture_tests = b.addRunArtifact(fixture_tests);
 
+    // Regression test for issue #44 — the `.simple` runner must
+    // initialize `std.testing.io_instance` so tests reaching for
+    // `std.testing.io` don't deadlock on linux. Routed through the
+    // `.simple` runner (which contains the fix) on purpose: a
+    // default-runner version of this test would always pass because
+    // the stdlib's runner does the per-test init itself.
+    const testing_io_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/testing_io_test.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+            .imports = &.{
+                .{ .name = "zspec", .module = zspec_mod },
+            },
+        }),
+        .test_runner = .{ .path = b.path("src/runner.zig"), .mode = .simple },
+    });
+
+    const run_testing_io_tests = b.addRunArtifact(testing_io_tests);
+
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_junit_unit_tests.step);
     test_step.dependOn(&run_fixture_tests.step);
     test_step.dependOn(&run_factory_union_tests.step);
     test_step.dependOn(&run_factory_zon_tests.step);
+    test_step.dependOn(&run_testing_io_tests.step);
 
     const example_step = b.step("example", "Run example tests");
     example_step.dependOn(&run_example_tests.step);

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -32,6 +32,28 @@ pub fn main() !void {
     // Use page allocator for JUnit writer (may need more memory for results)
     const page_allocator = std.heap.page_allocator;
 
+    // Initialize `std.testing.io_instance` so tests that reach for
+    // `std.testing.io` get a real `Io.Threaded` with a worker pool.
+    //
+    // `std.testing` declares (testing.zig:34-35):
+    //
+    //     pub var io_instance: Io.Threaded = undefined;
+    //     pub const io = if (builtin.is_test) io_instance.io() else ...;
+    //
+    // `Threaded.io(t)` bakes `&io_instance` into the returned `Io`'s
+    // `userdata` *at comptime* (lib/std/Io/Threaded.zig:1806). Without
+    // a runtime init, the global memory at that address stays zero —
+    // worker_threads = null, etc. — and every operation that needs to
+    // enqueue work onto the thread pool deadlocks on linux. macOS
+    // satisfies more zero-init paths, so the bug only shows up there.
+    //
+    // The stdlib's terminal runner does this re-init *per test* (see
+    // lib/compiler/test_runner.zig:273-282). For a `.simple`-mode
+    // runner a single global init is sufficient and cheaper than
+    // spinning up a worker pool for every test. See issue #44.
+    std.testing.io_instance = .init(std.testing.allocator, .{});
+    defer std.testing.io_instance.deinit();
+
     const env = Env.init(allocator);
     defer env.deinit(allocator);
 

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -45,7 +45,8 @@ pub fn main() !void {
     // a runtime init, the global memory at that address stays zero —
     // worker_threads = null, etc. — and every operation that needs to
     // enqueue work onto the thread pool deadlocks on linux. macOS
-    // satisfies more zero-init paths, so the bug only shows up there.
+    // happens to satisfy more zero-init paths along the way, so the
+    // bug stays hidden there and only manifests on linux.
     //
     // The stdlib's terminal runner does this re-init *per test* (see
     // lib/compiler/test_runner.zig:273-282). For a `.simple`-mode

--- a/tests/testing_io_test.zig
+++ b/tests/testing_io_test.zig
@@ -1,0 +1,77 @@
+//! Regression test for issue #44.
+//!
+//! When zspec's `src/runner.zig` is used as the `.simple` mode
+//! test_runner, every test using `std.testing.io` (which captures
+//! `&std.testing.io_instance` at comptime — see testing.zig:34-35
+//! and Io/Threaded.zig:1806) would route through a zero-initialized
+//! `Io.Threaded` and deadlock on linux for any op that needs the
+//! worker pool (tmpDir + writeFile, realPathFileAlloc, file-not-
+//! found readFileAlloc, …). macOS happened to satisfy more zero-init
+//! paths so the bug only surfaced on linux CI.
+//!
+//! The fix is a single-shot `testing.io_instance = .init(...)` at
+//! the top of `runner.main()`. This file ensures that fix stays in
+//! place: removing it puts CI back into the 6-hour-timeout regime.
+
+const std = @import("std");
+const zspec = @import("zspec");
+
+test {
+    zspec.runAll(@This());
+}
+
+pub const TestingIoTests = struct {
+    test "tmpDir + writeFile + readFileAlloc round-trips via std.testing.io" {
+        // The minimal sequence that deadlocked before the fix.
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        // `tmpDir` plants the dir at `.zig-cache/tmp/<sub_path>/`;
+        // build a cwd-relative path rather than going through
+        // `realPathFileAlloc(io, ".")` (which has its own linux
+        // deadlock signature in this same context — see #44).
+        const path = try std.fs.path.join(
+            std.testing.allocator,
+            &.{ ".zig-cache", "tmp", &tmp.sub_path, "regression.txt" },
+        );
+        defer std.testing.allocator.free(path);
+
+        const payload = "issue-44";
+        try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+            .sub_path = path,
+            .data = payload,
+        });
+
+        const read_back = try std.Io.Dir.cwd().readFileAlloc(
+            std.testing.io,
+            path,
+            std.testing.allocator,
+            .limited(1 << 14),
+        );
+        defer std.testing.allocator.free(read_back);
+
+        try std.testing.expectEqualStrings(payload, read_back);
+    }
+
+    test "readFileAlloc on a missing path returns FileNotFound, doesn't hang" {
+        // The other axis of the linux deadlock — readFileAlloc on a
+        // path that doesn't exist. Before the fix this never returned;
+        // after the fix it returns the expected error promptly.
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        const path = try std.fs.path.join(
+            std.testing.allocator,
+            &.{ ".zig-cache", "tmp", &tmp.sub_path, "does-not-exist.txt" },
+        );
+        defer std.testing.allocator.free(path);
+
+        const result = std.Io.Dir.cwd().readFileAlloc(
+            std.testing.io,
+            path,
+            std.testing.allocator,
+            .limited(1 << 14),
+        );
+        try std.testing.expectError(error.FileNotFound, result);
+    }
+};


### PR DESCRIPTION
## Summary

Fixes a linux-only deadlock for every consumer using zspec's `mode: .simple` test_runner whose tests touch `std.testing.io`.

`std.testing` declares `pub var io_instance: Io.Threaded = undefined` and `pub const io = io_instance.io()`. `Threaded.io(t)` bakes `&io_instance` into the returned Io's `userdata` at comptime — so without a runtime init, every call site is talking to a zero-initialized Threaded (no worker pool). On linux that deadlocks; on macOS more zero-init paths happen to work, hiding the bug.

The stdlib's terminal runner already does the right thing (lib/compiler/test_runner.zig:273-282 — per-test init+deinit). zspec's `.simple` runner didn't.

## Fix

Single-shot `testing.io_instance = .init(testing.allocator, .{})` at the top of `runner.main()`. Same memory address that comptime-baked `Io.userdata` pointers already reference — they now point at a properly initialized Threaded with a real worker pool.

Per-test re-init (matching the stdlib) is cheaper to skip in a `.simple` runner: 160 tests × spinning up a worker pool is way more than one global init covers.

## Test plan

- [x] New `tests/testing_io_test.zig` exercises the two deadlock signatures from #44 (tmpDir + writeFile round-trip; readFileAlloc on a missing path) under the `.simple` runner. Both passed in <5 ms locally and in an `ubuntu:24.04` docker container; both would have hung for 6 h on linux before this fix.
- [x] Full `zig build test` passes locally on macOS (57/57) and in the linux container.
- [x] End-to-end consumer verification: [labelle-toolkit/labelle-gui@6e11736](https://github.com/labelle-toolkit/labelle-gui/commit/6e11736) carried an equivalent fix as a project-local `beforeAll` hook — that project's test suite had been timing out at 6 h on every linux CI run since the 0.16 migration; it now passes 162/162 in <1 s.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)