### PR TITLE
release: bump .version to 0.9.3 (fix botched v0.9.2 internal version + ship #46)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zspec,
-    .version = "0.9.1",
+    .version = "0.9.2",
     .fingerprint = 0x940ac7516d8ba28d,
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zspec,
-    .version = "0.9.2",
+    .version = "0.9.3",
     .fingerprint = 0x940ac7516d8ba28d,
     .paths = .{
         "build.zig",


### PR DESCRIPTION
The v0.9.2 release tarball reports `.version = "0.9.1"` (the field wasn't bumped when v0.9.2 was tagged). That tag is immutable, so the clean fix is a new **0.9.3** that ships main's content — which already includes `runAll`/`refAllDeclsRecursive` (nested-spec discovery) **and** the unreleased #46 structural-equal fix — with a matching internal version.

Supersedes the original 0.9.2 target (re-tagging a published version isn't possible).